### PR TITLE
Replaced auto_ptr with unique_ptr.

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -122,7 +122,7 @@ class YAML_CPP_API Emitter : private noncopyable {
   bool CanEmitNewline() const;
 
  private:
-  std::auto_ptr<EmitterState> m_pState;
+  std::unique_ptr<EmitterState> m_pState;
   ostream_wrapper m_stream;
 };
 

--- a/include/yaml-cpp/parser.h
+++ b/include/yaml-cpp/parser.h
@@ -40,8 +40,8 @@ class YAML_CPP_API Parser : private noncopyable {
   void HandleTagDirective(const Token& token);
 
  private:
-  std::auto_ptr<Scanner> m_pScanner;
-  std::auto_ptr<Directives> m_pDirectives;
+  std::unique_ptr<Scanner> m_pScanner;
+  std::unique_ptr<Directives> m_pDirectives;
 };
 }
 

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -124,7 +124,7 @@ void EmitterState::StartedGroup(GroupType::value type) {
   const int lastGroupIndent = (m_groups.empty() ? 0 : m_groups.top().indent);
   m_curIndent += lastGroupIndent;
 
-  std::auto_ptr<Group> pGroup(new Group(type));
+  std::unique_ptr<Group> pGroup(new Group(type));
 
   // transfer settings (which last until this group is done)
   pGroup->modifiedSettings = m_modifiedSettings;
@@ -149,7 +149,7 @@ void EmitterState::EndedGroup(GroupType::value type) {
 
   // get rid of the current group
   {
-    std::auto_ptr<Group> pFinishedGroup = m_groups.pop();
+    std::unique_ptr<Group> pFinishedGroup = m_groups.pop();
     if (pFinishedGroup->type != type)
       return SetError(ErrorMsg::UNMATCHED_GROUP_TAG);
   }

--- a/src/ptr_stack.h
+++ b/src/ptr_stack.h
@@ -29,12 +29,12 @@ class ptr_stack : private YAML::noncopyable {
   std::size_t size() const { return m_data.size(); }
   bool empty() const { return m_data.empty(); }
 
-  void push(std::auto_ptr<T> t) {
+  void push(std::unique_ptr<T> &t) {
     m_data.push_back(NULL);
     m_data.back() = t.release();
   }
-  std::auto_ptr<T> pop() {
-    std::auto_ptr<T> t(m_data.back());
+  std::unique_ptr<T> pop() {
+    std::unique_ptr<T> t(m_data.back());
     m_data.pop_back();
     return t;
   }

--- a/src/ptr_vector.h
+++ b/src/ptr_vector.h
@@ -31,7 +31,7 @@ class ptr_vector : private YAML::noncopyable {
   std::size_t size() const { return m_data.size(); }
   bool empty() const { return m_data.empty(); }
 
-  void push_back(std::auto_ptr<T> t) {
+  void push_back(std::unique_ptr<T> &t) {
     m_data.push_back(NULL);
     m_data.back() = t.release();
   }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -233,7 +233,7 @@ const RegEx& Scanner::GetValueRegex() const {
 void Scanner::StartStream() {
   m_startedStream = true;
   m_simpleKeyAllowed = true;
-  std::auto_ptr<IndentMarker> pIndent(new IndentMarker(-1, IndentMarker::NONE));
+  std::unique_ptr<IndentMarker> pIndent(new IndentMarker(-1, IndentMarker::NONE));
   m_indentRefs.push_back(pIndent);
   m_indents.push(&m_indentRefs.back());
 }
@@ -281,7 +281,7 @@ Scanner::IndentMarker* Scanner::PushIndentTo(int column,
   if (InFlowContext())
     return 0;
 
-  std::auto_ptr<IndentMarker> pIndent(new IndentMarker(column, type));
+  std::unique_ptr<IndentMarker> pIndent(new IndentMarker(column, type));
   IndentMarker& indent = *pIndent;
   const IndentMarker& lastIndent = *m_indents.top();
 

--- a/src/setting.h
+++ b/src/setting.h
@@ -20,7 +20,7 @@ class Setting {
   Setting() : m_value() {}
 
   const T get() const { return m_value; }
-  std::auto_ptr<SettingChangeBase> set(const T& value);
+  std::unique_ptr<SettingChangeBase> set(const T& value);
   void restore(const Setting<T>& oldSetting) { m_value = oldSetting.get(); }
 
  private:
@@ -49,8 +49,8 @@ class SettingChange : public SettingChangeBase {
 };
 
 template <typename T>
-inline std::auto_ptr<SettingChangeBase> Setting<T>::set(const T& value) {
-  std::auto_ptr<SettingChangeBase> pChange(new SettingChange<T>(this));
+inline std::unique_ptr<SettingChangeBase> Setting<T>::set(const T& value) {
+  std::unique_ptr<SettingChangeBase> pChange(new SettingChange<T>(this));
   m_value = value;
   return pChange;
 }
@@ -75,11 +75,11 @@ class SettingChanges : private noncopyable {
       (*it)->pop();
   }
 
-  void push(std::auto_ptr<SettingChangeBase> pSettingChange) {
+  void push(std::unique_ptr<SettingChangeBase> pSettingChange) {
     m_settingChanges.push_back(pSettingChange.release());
   }
 
-  // like std::auto_ptr - assignment is transfer of ownership
+  // like std::unique_ptr - assignment is transfer of ownership
   SettingChanges& operator=(SettingChanges& rhs) {
     if (this == &rhs)
       return *this;

--- a/src/singledocparser.h
+++ b/src/singledocparser.h
@@ -53,7 +53,7 @@ class SingleDocParser : private noncopyable {
  private:
   Scanner& m_scanner;
   const Directives& m_directives;
-  std::auto_ptr<CollectionStack> m_pCollectionStack;
+  std::unique_ptr<CollectionStack> m_pCollectionStack;
 
   typedef std::map<std::string, anchor_t> Anchors;
   Anchors m_anchors;


### PR DESCRIPTION
Didn't know if you wanted to take a look at this as a piggy back for your C++11 and Boost deprecation.  Simple conversion from `auto_ptr` to `unique_ptr`.  I made the changes, fixed two problems involving the original code copying the `auto_ptr` which is no-no, looked through the usage for any other copy/move problems, and ran unit tests (they pass).
